### PR TITLE
feat: broadcast Telegram alerts + show last checked date

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import { scheduleRouter } from './routes/schedule';
 import { complainsRouter } from './routes/complains';
 import { docsRouter } from './routes/docs';
 import { startScheduleCron } from './services/schedule/cron';
+import { initTelegramSubscribers, pollSubscribers } from './services/telegram/alerter';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,8 @@ app.use(cors());
 app.use(express.json());
 
 initDb();
+initTelegramSubscribers();
+pollSubscribers().catch((err) => console.error('[telegram] Ошибка первичного опроса:', err));
 startScheduleCron();
 
 app.use('/api', healthRouter);

--- a/backend/src/routes/schedule.ts
+++ b/backend/src/routes/schedule.ts
@@ -21,6 +21,15 @@ scheduleRouter.get('/schedule', (_req: Request, res: Response) => {
       return
     }
 
+    // Последняя успешная проверка (cron или api)
+    const lastRun = db
+      .prepare(
+        `SELECT created_at FROM schedule_pipeline_runs
+         WHERE status IN ('success', 'no_changes')
+         ORDER BY created_at DESC LIMIT 1`,
+      )
+      .get() as { created_at: string } | undefined
+
     const etag = `"${row.file_hash}"`
 
     // Conditional request support
@@ -38,6 +47,7 @@ scheduleRouter.get('/schedule', (_req: Request, res: Response) => {
       schedule: JSON.parse(row.data),
       meta: {
         updatedAt: row.updated_at,
+        lastCheckedAt: lastRun?.created_at ?? row.updated_at,
         parseMethod: row.parse_method,
         fileHash: row.file_hash,
       },

--- a/backend/src/services/schedule/pipeline.ts
+++ b/backend/src/services/schedule/pipeline.ts
@@ -1,5 +1,5 @@
 import { getDb } from '../db'
-import { telegramAlerter } from '../telegram/alerter'
+import { telegramAlerter, pollSubscribers } from '../telegram/alerter'
 import { scrapeCarrierUrl } from './carrierScraper'
 import { downloadFromCloudMail } from './cloudMailDownloader'
 import { pipelineLogger } from './logger'
@@ -70,6 +70,9 @@ export async function runPipeline(opts: PipelineOptions = {}): Promise<PipelineR
     )
     return { ...result, durationMs: duration }
   }
+
+  // Обновляем список подписчиков перед отправкой алертов
+  await pollSubscribers()
 
   try {
     // ── Step 1: получить файл ──────────────────────────────────────────────
@@ -200,6 +203,9 @@ export async function runPipeline(opts: PipelineOptions = {}): Promise<PipelineR
       changesSummary: summary,
     })
   } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    pipelineLogger.error('save', msg)
+    await telegramAlerter.saveError(msg)
     return finish(pipelineError(err, 'save'))
   }
 }

--- a/backend/src/services/telegram/alerter.ts
+++ b/backend/src/services/telegram/alerter.ts
@@ -1,93 +1,186 @@
-const TELEGRAM_API = 'https://api.telegram.org'
+import { getDb } from '../db'
 
-let cachedChatId: string | null = null
+const TELEGRAM_API = 'https://api.telegram.org'
 
 function getToken(): string | undefined {
   return process.env.TELEGRAM_BOT_TOKEN
 }
 
 /**
- * Resolve chat_id: use TELEGRAM_CHAT_ID env if set,
- * otherwise call getUpdates to find the first chat that sent /start.
+ * Ensure telegram_subscribers table exists.
  */
-async function resolveChatId(token: string): Promise<string | null> {
-  if (cachedChatId) return cachedChatId
-
-  const envChatId = process.env.TELEGRAM_CHAT_ID
-  if (envChatId) {
-    cachedChatId = envChatId
-    return cachedChatId
-  }
-
-  try {
-    const res = await fetch(`${TELEGRAM_API}/bot${token}/getUpdates`)
-    if (!res.ok) return null
-    const data = (await res.json()) as { result?: Array<{ message?: { chat?: { id: number } } }> }
-    const chatId = data.result?.find((u) => u.message?.chat)?.message?.chat?.id
-    if (chatId) {
-      cachedChatId = String(chatId)
-      console.log(`[telegram] Chat ID получен автоматически: ${cachedChatId}`)
-      return cachedChatId
-    }
-  } catch (err) {
-    console.error(`[telegram] Не удалось получить chat_id: ${err}`)
-  }
-
-  return null
+export function initTelegramSubscribers(): void {
+  const db = getDb()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS telegram_subscribers (
+      chat_id TEXT PRIMARY KEY,
+      username TEXT,
+      first_name TEXT,
+      subscribed_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `)
 }
 
-async function sendMessage(text: string): Promise<void> {
+/**
+ * Poll getUpdates to discover new subscribers (users who sent /start).
+ * Stores discovered chat_ids in the database for persistent broadcasting.
+ * Uses update_offset stored in DB to avoid reprocessing.
+ */
+export async function pollSubscribers(): Promise<void> {
   const token = getToken()
   if (!token) return
 
-  const chatId = await resolveChatId(token)
-  if (!chatId) {
-    console.warn('[telegram] Chat ID не найден. Отправьте /start боту, затем перезапустите сервер.')
+  const db = getDb()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS telegram_state (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `)
+
+  const offsetRow = db
+    .prepare(`SELECT value FROM telegram_state WHERE key = 'update_offset'`)
+    .get() as { value: string } | undefined
+  const offset = offsetRow ? parseInt(offsetRow.value, 10) : 0
+
+  try {
+    const url = `${TELEGRAM_API}/bot${token}/getUpdates?offset=${offset}&timeout=0`
+    const res = await fetch(url)
+    if (!res.ok) return
+
+    const data = (await res.json()) as {
+      result?: Array<{
+        update_id: number
+        message?: {
+          text?: string
+          chat?: { id: number; username?: string; first_name?: string }
+        }
+      }>
+    }
+
+    if (!data.result?.length) return
+
+    let maxUpdateId = offset
+    for (const update of data.result) {
+      if (update.update_id >= maxUpdateId) {
+        maxUpdateId = update.update_id + 1
+      }
+
+      const chat = update.message?.chat
+      if (!chat) continue
+
+      // Store every chat that messages the bot (not just /start)
+      db.prepare(
+        `INSERT OR IGNORE INTO telegram_subscribers (chat_id, username, first_name)
+         VALUES (?, ?, ?)`,
+      ).run(String(chat.id), chat.username ?? null, chat.first_name ?? null)
+    }
+
+    // Persist offset so we don't reprocess updates
+    db.prepare(
+      `INSERT INTO telegram_state (key, value) VALUES ('update_offset', ?)
+       ON CONFLICT(key) DO UPDATE SET value = ?`,
+    ).run(String(maxUpdateId), String(maxUpdateId))
+  } catch (err) {
+    console.error(`[telegram] Ошибка при опросе подписчиков: ${err}`)
+  }
+}
+
+/**
+ * Get all subscriber chat_ids. Falls back to TELEGRAM_CHAT_ID env
+ * if no subscribers registered yet.
+ */
+function getSubscriberChatIds(): string[] {
+  try {
+    const db = getDb()
+    const rows = db
+      .prepare(`SELECT chat_id FROM telegram_subscribers`)
+      .all() as Array<{ chat_id: string }>
+
+    if (rows.length > 0) {
+      return rows.map((r) => r.chat_id)
+    }
+  } catch {
+    // Table might not exist yet
+  }
+
+  // Fallback: use env variable
+  const envChatId = process.env.TELEGRAM_CHAT_ID
+  if (envChatId) return [envChatId]
+
+  return []
+}
+
+async function broadcastMessage(text: string): Promise<void> {
+  const token = getToken()
+  if (!token) return
+
+  const chatIds = getSubscriberChatIds()
+  if (chatIds.length === 0) {
+    console.warn('[telegram] Нет подписчиков. Отправьте /start боту.')
     return
   }
 
-  try {
-    const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'HTML' }),
-    })
-    if (!res.ok) {
-      console.error(`[telegram] Ошибка отправки: HTTP ${res.status}`)
+  for (const chatId of chatIds) {
+    try {
+      const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'HTML' }),
+      })
+      if (!res.ok) {
+        const body = await res.text()
+        console.error(`[telegram] Ошибка отправки в ${chatId}: HTTP ${res.status} — ${body}`)
+
+        // If bot was blocked by user, remove subscriber
+        if (res.status === 403) {
+          try {
+            const db = getDb()
+            db.prepare(`DELETE FROM telegram_subscribers WHERE chat_id = ?`).run(chatId)
+            console.log(`[telegram] Подписчик ${chatId} удалён (бот заблокирован)`)
+          } catch { /* ignore */ }
+        }
+      }
+    } catch (err) {
+      console.error(`[telegram] Не удалось отправить в ${chatId}: ${err}`)
     }
-  } catch (err) {
-    console.error(`[telegram] Не удалось отправить сообщение: ${err}`)
   }
 }
 
 export const telegramAlerter = {
   /** Ошибка скрейпинга сайта перевозчика */
   scrapeError: (reason: string) =>
-    sendMessage(
+    broadcastMessage(
       `🚨 <b>SeverBus: ошибка скрейпинга</b>\n\nНе удалось найти ссылку на Word-файл 112С на сайте перевозчика.\n\n<code>${reason}</code>`,
     ),
 
   /** Ошибка скачивания с Cloud Mail.ru */
   downloadError: (reason: string) =>
-    sendMessage(
+    broadcastMessage(
       `🚨 <b>SeverBus: ошибка скачивания</b>\n\nНе удалось скачать файл с Cloud Mail.ru.\n\n<code>${reason}</code>`,
     ),
 
   /** Детерминированный парсинг не прошёл */
   parseError: (reason: string) =>
-    sendMessage(
+    broadcastMessage(
       `⚠️ <b>SeverBus: ошибка парсинга</b>\n\nДетерминированный парсер не прошёл. Расписание НЕ обновлено.\n\n<code>${reason}</code>`,
     ),
 
   /** Валидация не прошла */
   validationError: (details: string) =>
-    sendMessage(
+    broadcastMessage(
       `⚠️ <b>SeverBus: валидация не пройдена</b>\n\nРасписание НЕ обновлено.\n\n<code>${details}</code>`,
+    ),
+
+  /** Ошибка сохранения */
+  saveError: (reason: string) =>
+    broadcastMessage(
+      `🚨 <b>SeverBus: ошибка сохранения</b>\n\nНе удалось сохранить расписание в базу.\n\n<code>${reason}</code>`,
     ),
 
   /** Расписание успешно обновлено */
   scheduleUpdated: (summary: string, parseMethod: string, durationMs: number) =>
-    sendMessage(
+    broadcastMessage(
       `✅ <b>SeverBus: расписание обновлено</b>\n\n${summary}\nМетод: ${parseMethod}\nВремя: ${durationMs}ms`,
     ),
 }

--- a/frontend/src/features/Complains/ui/Fastreply.tsx
+++ b/frontend/src/features/Complains/ui/Fastreply.tsx
@@ -39,18 +39,17 @@ export const Fastreply: React.FC = () => {
 
 	const { addComplain } = useComplainsContext()
 
-	const isOnCooldown = useCallback(
-		(stopLabel: string): boolean => {
-			const until = cooldownsRef.current[stopLabel]
-			if (!until) return false
-			if (Date.now() >= until) {
-				delete cooldownsRef.current[stopLabel]
-				return false
-			}
-			return true
-		},
-		[],
-	)
+	const isOnCooldown = useCallback((stopLabel: string): boolean => {
+		const until = cooldownsRef.current[stopLabel]
+		if (!until) return false
+		if (Date.now() >= until) {
+			delete cooldownsRef.current[stopLabel]
+
+			return false
+		}
+
+		return true
+	}, [])
 
 	const handleFastReplyClick = (key: ComplainType | null): void => {
 		if (!key || !busStopNew) return

--- a/frontend/src/features/ScheduleInfo/ScheduleInfo.tsx
+++ b/frontend/src/features/ScheduleInfo/ScheduleInfo.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useGetChangelogQuery } from 'shared/api/scheduleApi'
-import { lastUpdatedAtSelector, lastCheckedAtSelector, scheduleSourceSelector } from 'shared/store/schedule/scheduleSlice'
+import {
+	lastCheckedAtSelector,
+	lastUpdatedAtSelector,
+	scheduleSourceSelector,
+} from 'shared/store/schedule/scheduleSlice'
 import { CardStyled, ContainerStyled, GrayTextStyled } from 'shared/ui/common'
 // ─── Styles ──────────────────────────────────────────────────────────────────
 import styled from 'styled-components'

--- a/frontend/src/features/ScheduleInfo/ScheduleInfo.tsx
+++ b/frontend/src/features/ScheduleInfo/ScheduleInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useGetChangelogQuery } from 'shared/api/scheduleApi'
-import { lastUpdatedAtSelector, scheduleSourceSelector } from 'shared/store/schedule/scheduleSlice'
+import { lastUpdatedAtSelector, lastCheckedAtSelector, scheduleSourceSelector } from 'shared/store/schedule/scheduleSlice'
 import { CardStyled, ContainerStyled, GrayTextStyled } from 'shared/ui/common'
 // ─── Styles ──────────────────────────────────────────────────────────────────
 import styled from 'styled-components'
@@ -20,6 +20,10 @@ const UpdatedLabelStyled = styled.span`
 
 const UpdatedDateStyled = styled.b`
 	color: #1191fb;
+`
+
+const CheckedDateStyled = styled.b`
+	color: #2e7d32;
 `
 
 const ToggleButtonStyled = styled.button`
@@ -74,6 +78,7 @@ function formatDate(iso: string): string {
 export const ScheduleInfo: React.FC = () => {
 	const source = useSelector(scheduleSourceSelector)
 	const lastUpdatedAt = useSelector(lastUpdatedAtSelector)
+	const lastCheckedAt = useSelector(lastCheckedAtSelector)
 	const [showChangelog, setShowChangelog] = useState(false)
 
 	const { data: changelog } = useGetChangelogQuery({ limit: 5 }, { skip: !showChangelog })
@@ -81,13 +86,28 @@ export const ScheduleInfo: React.FC = () => {
 	// Не показываем блок если расписание захардкожено и нет даты обновления
 	if (source === `hardcoded` && !lastUpdatedAt) return null
 
+	// Показываем «проверено» если дата проверки отличается от даты обновления
+	const showCheckedAt = lastCheckedAt && lastCheckedAt !== lastUpdatedAt
+
 	return (
 		<ContainerStyled>
 			<CardStyled>
 				<UpdatedRowStyled>
 					<UpdatedLabelStyled>
-						🕐 Расписание обновлено:{` `}
-						<UpdatedDateStyled>{lastUpdatedAt ? formatDate(lastUpdatedAt) : `—`}</UpdatedDateStyled>
+						{showCheckedAt ? (
+							<>
+								✅ Проверено:{` `}
+								<CheckedDateStyled>{formatDate(lastCheckedAt)}</CheckedDateStyled>
+								<br />
+								🔄 Обновлено:{` `}
+								<UpdatedDateStyled>{lastUpdatedAt ? formatDate(lastUpdatedAt) : `—`}</UpdatedDateStyled>
+							</>
+						) : (
+							<>
+								✅ Обновлено:{` `}
+								<UpdatedDateStyled>{lastUpdatedAt ? formatDate(lastUpdatedAt) : `—`}</UpdatedDateStyled>
+							</>
+						)}
 					</UpdatedLabelStyled>
 
 					{changelog !== undefined || showChangelog ? (

--- a/frontend/src/shared/api/scheduleApi.ts
+++ b/frontend/src/shared/api/scheduleApi.ts
@@ -8,6 +8,7 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 
 export interface ScheduleMeta {
 	updatedAt: string
+	lastCheckedAt: string
 	parseMethod: string
 	fileHash: string
 }

--- a/frontend/src/shared/store/schedule/scheduleSlice.ts
+++ b/frontend/src/shared/store/schedule/scheduleSlice.ts
@@ -11,6 +11,7 @@ export interface BusStopInfoState {
 	nextDayKey: number
 	scheduleSource: 'hardcoded' | 'api' | 'cache'
 	lastUpdatedAt: string | null
+	lastCheckedAt: string | null
 	parseMethod: string | null
 }
 
@@ -20,6 +21,7 @@ const initialState: BusStopInfoState = {
 	nextDayKey: getNextDay(new Date().getDay()),
 	scheduleSource: `hardcoded`,
 	lastUpdatedAt: null,
+	lastCheckedAt: null,
 	parseMethod: null,
 }
 
@@ -36,12 +38,14 @@ export const busStopInfoSlice = createSlice({
 				schedule: ISchedule
 				source: 'api' | 'cache'
 				updatedAt: string
+				lastCheckedAt: string
 				parseMethod: string
 			}>,
 		) => {
 			state.schedule = action.payload.schedule
 			state.scheduleSource = action.payload.source
 			state.lastUpdatedAt = action.payload.updatedAt
+			state.lastCheckedAt = action.payload.lastCheckedAt
 			state.parseMethod = action.payload.parseMethod
 		},
 		setCurrentDayKey: (state, action: PayloadAction<number>) => {
@@ -59,5 +63,6 @@ export const nextDaySelector = (state: RootState): number => state.scheduleSlice
 export const scheduleSourceSelector = (state: RootState): 'cache' | 'api' | 'hardcoded' =>
 	state.scheduleSlice.scheduleSource
 export const lastUpdatedAtSelector = (state: RootState): string | null => state.scheduleSlice.lastUpdatedAt
+export const lastCheckedAtSelector = (state: RootState): string | null => state.scheduleSlice.lastCheckedAt
 
 export default busStopInfoSlice.reducer

--- a/frontend/src/shared/store/schedule/useScheduleLoader.ts
+++ b/frontend/src/shared/store/schedule/useScheduleLoader.ts
@@ -23,6 +23,7 @@ export function useScheduleLoader(): void {
 					schedule: cached.schedule,
 					source: `cache`,
 					updatedAt: cached.meta.updatedAt,
+					lastCheckedAt: cached.meta.lastCheckedAt,
 					parseMethod: cached.meta.parseMethod,
 				}),
 			)
@@ -40,6 +41,7 @@ export function useScheduleLoader(): void {
 				schedule: data.schedule,
 				source: `api`,
 				updatedAt: data.meta.updatedAt,
+				lastCheckedAt: data.meta.lastCheckedAt,
 				parseMethod: data.meta.parseMethod,
 			}),
 		)


### PR DESCRIPTION
## Summary

### Telegram alerts → broadcast всем подписчикам
- Вместо отправки в один `chat_id`, алерты теперь уходят **всем**, кто написал боту
- Chat ID хранятся в SQLite-таблице `telegram_subscribers` (переживают перезапуск)
- При HTTP 403 (бот заблокирован) подписчик автоматически удаляется
- Fallback на `TELEGRAM_CHAT_ID` env если в базе пусто
- Добавлен `saveError` алерт — ранее ошибки на этапе сохранения молча логировались

### Фронтенд: «Проверено» vs «Обновлено»
- Backend отдаёт `lastCheckedAt` (последний успешный прогон пайплайна) отдельно от `updatedAt`
- На фронте: если даты различаются — показываем обе:
  - ✅ **Проверено**: дата последней проверки (зелёный)
  - 🔄 **Обновлено**: дата последнего изменения расписания (синий)
- Если даты совпадают — показываем только «Обновлено»

## ⚠️ TODO перед деплоем

**Создать нового Telegram-бота** для алертов (`@BotFather → /newbot`).
Сейчас один токен может использоваться двумя сервисами — это вызывает конфликт при чтении `getUpdates` (один сервис забирает update, второй его не видит). Нужен отдельный бот, чей токен используется **только** этим бэкендом. Обновить `TELEGRAM_BOT_TOKEN` в secrets деплоя.

## Test plan

- [ ] Отправить `/start` боту с нескольких аккаунтов
- [ ] Вызвать `POST /api/schedule/refresh` — проверить что алерт пришёл **всем**
- [ ] Перезапустить контейнер — проверить что подписчики сохранились в БД
- [ ] Заблокировать бота с одного аккаунта — проверить удаление из подписчиков
- [ ] Проверить что на фронте отображается «Проверено» и «Обновлено» с разными датами
- [ ] Проверить что при совпадении дат показывается только «Обновлено»

https://claude.ai/code/session_01Kmj4EyscUqFw2Nowfeik2m