### PR TITLE
Исключить технические страницы из поисковой индексации

### DIFF
--- a/backend/src/routes/docs.ts
+++ b/backend/src/routes/docs.ts
@@ -264,6 +264,9 @@ const spec = {
 
 export const docsRouter = Router()
 
-docsRouter.use('/docs', swaggerUi.serve, swaggerUi.setup(spec, {
+docsRouter.use('/docs', (_req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+  next();
+}, swaggerUi.serve, swaggerUi.setup(spec, {
   customSiteTitle: 'SeverBus API Docs',
 }))

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -29,6 +29,7 @@ function basicAuth(req: Request, res: Response, next: () => void): void {
 
 /** GET /api/health — monitoring dashboard (password protected) */
 healthRouter.get('/health', basicAuth, (_req: Request, res: Response) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow');
   const uptime = process.uptime();
   const memoryUsage = process.memoryUsage();
   const db = getDb();

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,2 +1,9 @@
 User-agent: *
 Allow: /
+
+Disallow: /dev
+Disallow: /game
+Disallow: /api/docs
+Disallow: /api/health
+
+Sitemap: https://severbus.ru/sitemap.xml


### PR DESCRIPTION
Добавлены правила Disallow в robots.txt для /dev, /game, /api/docs, /api/health.
Добавлены заголовки X-Robots-Tag: noindex, nofollow для /api/docs и /api/health.

https://claude.ai/code/session_01HCqhZCYm833yugJn7FBULi