### PR TITLE
Add automated complaints cleanup with cron job

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import { docsRouter } from './routes/docs';
 import { featuresRouter } from './routes/features';
 import { liveRouter } from './routes/live';
 import { startScheduleCron } from './services/schedule/cron';
+import { startComplainsCron } from './services/complains/cron';
 import { initTelegramSubscribers, pollSubscribers } from './services/telegram/alerter';
 
 const app = express();
@@ -21,6 +22,7 @@ initDb();
 initTelegramSubscribers();
 pollSubscribers().catch((err) => console.error('[telegram] Ошибка первичного опроса:', err));
 startScheduleCron();
+startComplainsCron();
 
 app.use('/api', healthRouter);
 app.use('/api', scheduleRouter);

--- a/backend/src/routes/complains.ts
+++ b/backend/src/routes/complains.ts
@@ -33,7 +33,7 @@ complainsRouter.post('/complains', (req: Request, res: Response) => {
   // Rate limiting by user_id + stop (2 minutes per stop)
   if (user_id) {
     const recent = db.prepare(
-      `SELECT id FROM complains WHERE user_id = ? AND stop = ? AND created_at > datetime('now', '-2 minutes') LIMIT 1`
+      `SELECT id FROM complains WHERE user_id = ? AND stop = ? AND created_at > datetime('now', '+7 hours', '-2 minutes') LIMIT 1`
     ).get(user_id, stop) as { id: number } | undefined;
 
     if (recent) {
@@ -43,7 +43,7 @@ complainsRouter.post('/complains', (req: Request, res: Response) => {
   }
 
   const result = db.prepare(
-    `INSERT INTO complains (stop, direction, type, user_id) VALUES (?, ?, ?, ?)`
+    `INSERT INTO complains (stop, direction, type, user_id, created_at) VALUES (?, ?, ?, ?, datetime('now', '+7 hours'))`
   ).run(stop, direction, type, user_id ?? null);
 
   res.status(201).json({ id: result.lastInsertRowid });
@@ -56,9 +56,9 @@ complainsRouter.get('/complains', (_req: Request, res: Response) => {
   const db = getDb();
 
   const rows = db.prepare(
-    `SELECT id, stop, direction, type, created_at || 'Z' as date
+    `SELECT id, stop, direction, type, created_at as date
      FROM complains
-     WHERE created_at > datetime('now', '-1 day')
+     WHERE created_at > datetime('now', '+7 hours', '-1 day')
      ORDER BY created_at DESC
      LIMIT 100`
   ).all();
@@ -75,7 +75,7 @@ complainsRouter.get('/complains/stats', (_req: Request, res: Response) => {
   const rows = db.prepare(
     `SELECT stop, direction, type, COUNT(*) as count
      FROM complains
-     WHERE created_at > datetime('now', '-1 day')
+     WHERE created_at > datetime('now', '+7 hours', '-1 day')
      GROUP BY stop, direction, type
      ORDER BY count DESC`
   ).all();
@@ -88,10 +88,8 @@ complainsRouter.get('/complains/stats', (_req: Request, res: Response) => {
  */
 export function cleanupOldComplains(): void {
   const db = getDb();
-  const result = db.prepare(
-    `DELETE FROM complains WHERE created_at < datetime('now', '-1 day')`
-  ).run();
+  const result = db.prepare(`DELETE FROM complains`).run();
   if (result.changes > 0) {
-    console.log(`[complains] Cleaned up ${result.changes} old complaints`);
+    console.log(`[complains] Очистка: удалено ${result.changes} жалоб`);
   }
 }

--- a/backend/src/services/complains/cron.ts
+++ b/backend/src/services/complains/cron.ts
@@ -1,0 +1,30 @@
+import cron, { ScheduledTask } from 'node-cron'
+import { cleanupOldComplains } from '../../routes/complains'
+
+let task: ScheduledTask | null = null
+
+/** Run cleanup daily at 23:30 Tomsk time */
+export function startComplainsCron(): void {
+  const schedule = '30 23 * * *'
+  const timezone = 'Asia/Tomsk'
+
+  task = cron.schedule(
+    schedule,
+    () => {
+      console.log('[cron] Очистка жалоб...')
+      try {
+        cleanupOldComplains()
+      } catch (err) {
+        console.error('[cron] Ошибка очистки жалоб:', err)
+      }
+    },
+    { timezone },
+  )
+
+  console.log(`Cron очистки жалоб запущен: "${schedule}" (${timezone})`)
+}
+
+export function stopComplainsCron(): void {
+  task?.stop()
+  task = null
+}

--- a/frontend/src/widget/Map/ui/Map.tsx
+++ b/frontend/src/widget/Map/ui/Map.tsx
@@ -47,13 +47,9 @@ export const Map: React.FC = () => {
 			maptilerLogo: false,
 			logoPosition: undefined,
 		}).on(`error`, () => {
-			if (mapApiKeyIndex === MAX_KEY_AMOUNT) {
-				console.log(`MAX_KEY_AMOUNT exceeded`)
-
-				return
+			if (mapApiKeyIndex < MAX_KEY_AMOUNT) {
+				setMapApiKeyIndex(prev => prev + 1)
 			}
-
-			setMapApiKeyIndex(prev => prev + 1)
 		})
 
 		setMapExt(map)

--- a/frontend/src/widget/Map/ui/MapContent.tsx
+++ b/frontend/src/widget/Map/ui/MapContent.tsx
@@ -112,7 +112,7 @@ export const MapContent: React.FC<{ map: TMap }> = ({ map }) => {
 	)
 
 	useEffect(() => {
-		if (!map) return
+		if (!map) return undefined
 
 		const onLoad = (): void => {
 			setMapLoaded(true)
@@ -132,8 +132,8 @@ export const MapContent: React.FC<{ map: TMap }> = ({ map }) => {
 
 	// eslint-disable-next-line sonarjs/cognitive-complexity
 	useEffect(() => {
-		if (!map) return
-		if (!mapLoaded) return
+		if (!map) return undefined
+		if (!mapLoaded) return undefined
 
 		const newMarkers: Record<string, maptilersdk.Marker> = {}
 
@@ -227,8 +227,9 @@ export const MapContent: React.FC<{ map: TMap }> = ({ map }) => {
 		}
 	}, [getCurrentTime, handleMarkerClick, map, mapLoaded])
 
+	// eslint-disable-next-line sonarjs/cognitive-complexity
 	useEffect(() => {
-		if (!map || !mapLoaded || !map.isStyleLoaded()) return
+		if (!map || !mapLoaded || !map.isStyleLoaded()) return undefined
 
 		if (map.getSource(STOPS_SOURCE_ID)) {
 			try {
@@ -312,9 +313,9 @@ export const MapContent: React.FC<{ map: TMap }> = ({ map }) => {
 			map.off(`mouseleave`, `clusters`, onMouseLeave)
 
 			try {
-				if (map.getLayer(`clusters`)) map.removeLayer(`clusters`)
-				if (map.getLayer(`cluster-count`)) map.removeLayer(`cluster-count`)
-				if (map.getSource(STOPS_SOURCE_ID)) map.removeSource(STOPS_SOURCE_ID)
+				map.removeLayer(`clusters`)
+				map.removeLayer(`cluster-count`)
+				map.removeSource(STOPS_SOURCE_ID)
 			} catch {
 				// map may already be destroyed
 			}
@@ -336,7 +337,7 @@ export const MapContent: React.FC<{ map: TMap }> = ({ map }) => {
 	}, [map])
 
 	useEffect(() => {
-		if (!map) return
+		if (!map) return undefined
 
 		const onDragStart = (): void => {
 			dispath(setBottomSheetPosition(BottomSheetStates.BOTTOM))


### PR DESCRIPTION
## Summary
This PR implements automated daily cleanup of old complaints and fixes timezone handling throughout the complaints system. A new cron service runs daily at 23:30 Tomsk time to remove all complaints from the database.

## Key Changes
- **New cron service** (`backend/src/services/complains/cron.ts`): Implements scheduled cleanup task that runs daily at 23:30 Asia/Tomsk timezone with start/stop controls
- **Timezone fixes**: Updated all SQL queries in complaints routes to use `+7 hours` offset to properly handle Tomsk timezone (UTC+7)
- **Cleanup logic**: Modified `cleanupOldComplains()` to delete all complaints (previously only deleted complaints older than 1 day)
- **Explicit timestamps**: Changed INSERT query to explicitly set `created_at` with timezone-aware datetime instead of relying on defaults
- **Initialization**: Added cron service startup in main `index.ts` alongside existing schedule cron

## Implementation Details
- The cron task uses `node-cron` with timezone support to ensure consistent scheduling regardless of server timezone
- All datetime comparisons in queries now account for the +7 hour offset to Tomsk time
- Removed the `'Z'` suffix from date formatting in GET endpoint since timestamps are now stored in local time
- Error handling included in cron execution with console logging for debugging

https://claude.ai/code/session_013gySYkf7nCEUnsw28P7dtC