### PR TITLE
fix: prevent scroll leaking from stops picker to bottom sheet

### DIFF
--- a/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
+++ b/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
@@ -27,6 +27,7 @@
 	display: flex;
 	align-items: flex-end;
 	justify-content: center;
+	overscroll-behavior: contain;
 }
 
 .modal {
@@ -65,7 +66,10 @@
 }
 
 .list {
+	flex: 1;
+	min-height: 0;
 	overflow-y: auto;
+	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
 	padding: 8px 0 24px;
 }


### PR DESCRIPTION
The stops list inside StopPickerModal wasn't properly scrolling because
it lacked flex constraints (flex: 1, min-height: 0) within the 70vh modal.
Scroll events were passing through to the bottom sheet underneath.
Added overscroll-behavior: contain to prevent scroll chaining.

https://claude.ai/code/session_01CBuf3APy3NkYix6tbhD7XC