### PR TITLE
Fix scroll position restoration in StopPickerModal

### DIFF
--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
 declare const __APP_VERSION__: string
 declare module '*.svg' {
 	const content: string

--- a/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
+++ b/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
@@ -32,14 +32,14 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 
 	useEffect(() => {
 		if (isOpen) {
-			const scrollY = window.scrollY
+			const { scrollY } = window
 			document.body.style.overflow = `hidden`
 			document.body.style.position = `fixed`
 			document.body.style.top = `-${scrollY}px`
 			document.body.style.left = `0`
 			document.body.style.right = `0`
 		} else {
-			const top = document.body.style.top
+			const { top } = document.body.style
 			document.body.style.overflow = ``
 			document.body.style.position = ``
 			document.body.style.top = ``
@@ -51,7 +51,7 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 		}
 
 		return (): void => {
-			const top = document.body.style.top
+			const { top } = document.body.style
 			document.body.style.overflow = ``
 			document.body.style.position = ``
 			document.body.style.top = ``

--- a/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
+++ b/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
@@ -32,13 +32,34 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 
 	useEffect(() => {
 		if (isOpen) {
+			const scrollY = window.scrollY
 			document.body.style.overflow = `hidden`
+			document.body.style.position = `fixed`
+			document.body.style.top = `-${scrollY}px`
+			document.body.style.left = `0`
+			document.body.style.right = `0`
 		} else {
+			const top = document.body.style.top
 			document.body.style.overflow = ``
+			document.body.style.position = ``
+			document.body.style.top = ``
+			document.body.style.left = ``
+			document.body.style.right = ``
+			if (top) {
+				window.scrollTo(0, -parseInt(top, 10))
+			}
 		}
 
 		return (): void => {
+			const top = document.body.style.top
 			document.body.style.overflow = ``
+			document.body.style.position = ``
+			document.body.style.top = ``
+			document.body.style.left = ``
+			document.body.style.right = ``
+			if (top) {
+				window.scrollTo(0, -parseInt(top, 10))
+			}
 		}
 	}, [isOpen])
 

--- a/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
+++ b/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
@@ -28,6 +28,7 @@
 	align-items: flex-end;
 	justify-content: center;
 	overscroll-behavior: contain;
+	touch-action: none;
 }
 
 .modal {
@@ -71,6 +72,7 @@
 	overflow-y: auto;
 	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
+	touch-action: pan-y;
 	padding: 8px 0 24px;
 }
 

--- a/frontend/src/widget/Map/ui/Map.tsx
+++ b/frontend/src/widget/Map/ui/Map.tsx
@@ -7,6 +7,7 @@ import { MapContainerStyled } from './Map.styled'
 import { MapContent } from './MapContent'
 
 const getMapApiKey = (attempt: number): string => {
+	// eslint-disable-next-line no-console
 	console.info(
 		`trying MAPTILER_KEY_${attempt} ${
 			process.env[`MAPTILER_KEY_${attempt}`] ? `KEY exists` : `KEY does not exists`


### PR DESCRIPTION
## Summary
Improved the StopPickerModal component to properly preserve and restore the page scroll position when the modal opens and closes, while also enhancing touch interaction handling.

## Key Changes
- **Scroll position preservation**: Capture the current scroll position (`window.scrollY`) when the modal opens and restore it when the modal closes
- **Body positioning**: Apply `position: fixed` to the body element while the modal is open to prevent background scrolling, using the negative scroll position as the `top` value
- **Cleanup on unmount**: Ensure scroll position is restored in the cleanup function to handle component unmounting gracefully
- **Touch interaction improvements**: 
  - Added `touch-action: none` to the modal overlay to prevent unintended touch gestures
  - Added `touch-action: pan-y` to the scrollable content area to allow vertical panning while preventing horizontal gestures

## Implementation Details
The scroll restoration logic works by:
1. Storing `window.scrollY` before fixing the body position
2. Setting `top: -${scrollY}px` on the fixed body to offset the visual position
3. Parsing the stored `top` value and calling `window.scrollTo(0, -parseInt(top, 10))` to restore the original scroll position when closing

https://claude.ai/code/session_018BnZVGXkRmNJAwMWXfvXxZ