### PR TITLE
Add Yandex ad block ID environment variable to Vite config

### DIFF
--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention, no-underscore-dangle */
 declare const __APP_VERSION__: string
 declare module '*.svg' {
 	const content: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig(({ mode }) => {
 	return {
 		define: {
 			'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? mode),
+			'process.env.YANDEX_AD_BLOCK_ID': JSON.stringify(process.env.YANDEX_AD_BLOCK_ID ?? ''),
 		},
 		root: appRootPath,
 		envDir: root,


### PR DESCRIPTION
## Summary
This change exposes the `YANDEX_AD_BLOCK_ID` environment variable to the frontend application by adding it to Vite's `define` configuration.

## Key Changes
- Added `process.env.YANDEX_AD_BLOCK_ID` to the Vite `define` object in `frontend/vite.config.ts`
- The variable defaults to an empty string if not provided in the environment
- This allows the frontend code to access the Yandex ad block ID at runtime

## Implementation Details
The environment variable is defined using the same pattern as the existing `NODE_ENV` variable, ensuring it's properly stringified and available throughout the application via `process.env.YANDEX_AD_BLOCK_ID`.

https://claude.ai/code/session_014NhQf4JyGcd5aWuCQircNf