### PR TITLE
Simplify StopPickerModal scroll lock implementation

### DIFF
--- a/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
+++ b/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
@@ -32,34 +32,16 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 
 	useEffect(() => {
 		if (isOpen) {
-			const { scrollY } = window
+			document.documentElement.style.overflow = `hidden`
 			document.body.style.overflow = `hidden`
-			document.body.style.position = `fixed`
-			document.body.style.top = `-${scrollY}px`
-			document.body.style.left = `0`
-			document.body.style.right = `0`
 		} else {
-			const { top } = document.body.style
+			document.documentElement.style.overflow = ``
 			document.body.style.overflow = ``
-			document.body.style.position = ``
-			document.body.style.top = ``
-			document.body.style.left = ``
-			document.body.style.right = ``
-			if (top) {
-				window.scrollTo(0, -parseInt(top, 10))
-			}
 		}
 
 		return (): void => {
-			const { top } = document.body.style
+			document.documentElement.style.overflow = ``
 			document.body.style.overflow = ``
-			document.body.style.position = ``
-			document.body.style.top = ``
-			document.body.style.left = ``
-			document.body.style.right = ``
-			if (top) {
-				window.scrollTo(0, -parseInt(top, 10))
-			}
 		}
 	}, [isOpen])
 

--- a/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
+++ b/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
@@ -28,7 +28,6 @@
 	align-items: flex-end;
 	justify-content: center;
 	overscroll-behavior: contain;
-	touch-action: none;
 }
 
 .modal {
@@ -71,8 +70,6 @@
 	min-height: 0;
 	overflow-y: auto;
 	overscroll-behavior: contain;
-	-webkit-overflow-scrolling: touch;
-	touch-action: pan-y;
 	padding: 8px 0 24px;
 }
 


### PR DESCRIPTION
## Summary
Refactored the scroll lock mechanism in StopPickerModal to use a simpler and more standard approach for preventing background scrolling when the modal is open.

## Key Changes
- **Simplified scroll prevention logic**: Replaced manual scroll position tracking and window scroll restoration with a cleaner `overflow: hidden` approach on both `document.documentElement` and `document.body`
- **Removed manual scroll restoration**: Eliminated the complex logic that saved scroll position via `scrollY` and restored it using `window.scrollTo()`, which was error-prone and unnecessary
- **Cleaned up CSS**: Removed `touch-action` properties (`none` and `pan-y`) and `-webkit-overflow-scrolling: touch` that are no longer needed with the simplified approach

## Implementation Details
The new approach leverages CSS `overflow: hidden` on the document root and body elements to prevent scrolling, which is:
- More reliable across browsers
- Simpler to maintain
- Less prone to scroll position bugs
- A standard pattern for modal implementations

The cleanup also removes touch-specific CSS properties that were likely workarounds for the previous implementation approach.

https://claude.ai/code/session_016njqUW6bwtsvTvXhBqi9zh