### PR TITLE
fix: restore original StopPickerModal scroll behavior for iOS 17

### DIFF
--- a/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
+++ b/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
@@ -32,15 +32,12 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 
 	useEffect(() => {
 		if (isOpen) {
-			document.documentElement.style.overflow = `hidden`
 			document.body.style.overflow = `hidden`
 		} else {
-			document.documentElement.style.overflow = ``
 			document.body.style.overflow = ``
 		}
 
 		return (): void => {
-			document.documentElement.style.overflow = ``
 			document.body.style.overflow = ``
 		}
 	}, [isOpen])

--- a/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
+++ b/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
@@ -27,7 +27,6 @@
 	display: flex;
 	align-items: flex-end;
 	justify-content: center;
-	overscroll-behavior: contain;
 }
 
 .modal {
@@ -66,10 +65,8 @@
 }
 
 .list {
-	flex: 1;
-	min-height: 0;
 	overflow-y: auto;
-	overscroll-behavior: contain;
+	-webkit-overflow-scrolling: touch;
 	padding: 8px 0 24px;
 }
 


### PR DESCRIPTION
Remove CSS properties added during styled-components to CSS modules migration that broke scrolling on iOS 17: overscroll-behavior on overlay and list, flex:1 and min-height:0 on list. Restore -webkit-overflow-scrolling:touch. Simplify body scroll lock.

https://claude.ai/code/session_016njqUW6bwtsvTvXhBqi9zh