### PR TITLE
fix: block touch events on overlay via JS to fix iOS 17 scroll

### DIFF
--- a/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
+++ b/frontend/src/widget/BusStop/ui/StopPickerModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { IOption, StopKeys } from 'shared/store/busStop/Stops'
 
@@ -18,6 +18,8 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 	placeholder = `Выберите остановку`,
 }) => {
 	const [isOpen, setIsOpen] = useState(false)
+	const listRef = useRef<HTMLDivElement>(null)
+	const overlayRef = useRef<HTMLDivElement>(null)
 
 	const displayLabel = options.find(o => o.value === value)?.label
 
@@ -31,14 +33,28 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 	}
 
 	useEffect(() => {
-		if (isOpen) {
-			document.body.style.overflow = `hidden`
-		} else {
+		if (!isOpen) {
 			document.body.style.overflow = ``
+			return (): void => {}
 		}
+
+		document.body.style.overflow = `hidden`
+
+		const overlay = overlayRef.current
+		const list = listRef.current
+
+		const handleTouchMove = (e: TouchEvent): void => {
+			if (list && list.contains(e.target as Node)) {
+				return
+			}
+			e.preventDefault()
+		}
+
+		overlay?.addEventListener(`touchmove`, handleTouchMove, { passive: false })
 
 		return (): void => {
 			document.body.style.overflow = ``
+			overlay?.removeEventListener(`touchmove`, handleTouchMove)
 		}
 	}, [isOpen])
 
@@ -53,6 +69,7 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 			{isOpen &&
 				createPortal(
 					<div
+						ref={overlayRef}
 						className={styles.overlay}
 						onClick={(): void => setIsOpen(false)}
 						role="button"
@@ -79,7 +96,7 @@ export const StopPickerModal: React.FC<StopPickerModalProps> = ({
 									&times;
 								</button>
 							</div>
-							<div className={styles.list}>
+							<div ref={listRef} className={styles.list}>
 								{stopsOnly.map(option => (
 									<button
 										key={option.value as string}

--- a/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
+++ b/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
@@ -65,8 +65,11 @@
 }
 
 .list {
+	flex: 1;
+	min-height: 0;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
+	overscroll-behavior: contain;
 	padding: 8px 0 24px;
 }
 


### PR DESCRIPTION
Use native touchmove listener with passive:false on overlay to preventDefault when touch is outside the scrollable list. This prevents map/bottom-sheet under the modal from capturing touches while allowing the stops list to scroll normally.

https://claude.ai/code/session_016njqUW6bwtsvTvXhBqi9zh