### PR TITLE
fix: make stops list scrollable on iOS by constraining height

### DIFF
--- a/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
+++ b/frontend/src/widget/BusStop/ui/stopPickerModal.module.css
@@ -35,6 +35,7 @@
 	width: 100%;
 	max-width: 768px;
 	max-height: 70vh;
+	overflow: hidden;
 	display: flex;
 	flex-direction: column;
 }
@@ -65,6 +66,8 @@
 }
 
 .list {
+	flex: 1;
+	min-height: 0;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 	padding: 8px 0 24px;


### PR DESCRIPTION
Add overflow:hidden on .modal and flex:1 + min-height:0 on .list so the list gets a computed height and overflow-y:auto works on iOS.

https://claude.ai/code/session_016njqUW6bwtsvTvXhBqi9zh