### PR TITLE
fix: modal scroll on iPhone

### DIFF
--- a/frontend/src/features/Donate/ui/styled.module.css
+++ b/frontend/src/features/Donate/ui/styled.module.css
@@ -59,9 +59,9 @@
 	inset: 0;
 	z-index: 1100;
 	background: rgba(0, 0, 0, 0.4);
-	display: flex;
-	align-items: center;
-	justify-content: center;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	overscroll-behavior: contain;
 	padding: 16px;
 }
 
@@ -73,6 +73,7 @@
 	max-width: 400px;
 	width: 100%;
 	text-align: center;
+	margin: 16px auto;
 }
 
 .modalClose {

--- a/frontend/src/features/MapAdBanner/ui/MapAdBanner.module.css
+++ b/frontend/src/features/MapAdBanner/ui/MapAdBanner.module.css
@@ -5,9 +5,9 @@
   inset: 0;
   z-index: 1100;
   background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
   padding: 16px;
 }
 
@@ -18,10 +18,7 @@
   padding: 28px 20px 24px;
   max-width: 400px;
   width: 100%;
-  max-height: 80vh;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
+  margin: 16px auto;
 }
 
 .modalClose {

--- a/frontend/src/features/MapAdBanner/ui/MapAdBanner.tsx
+++ b/frontend/src/features/MapAdBanner/ui/MapAdBanner.tsx
@@ -17,10 +17,10 @@ const CANVAS_W = 240
 const CANVAS_H = 132
 
 const DEFAULT_MESSAGES: BannerMessage[] = [
-	{ id: -1, author_name: ``, message: `Продам опель астра`, created_at: `` },
-	{ id: -2, author_name: ``, message: `Ищу девушку с остановки`, created_at: `` },
-	{ id: -3, author_name: ``, message: `Хочу лето`, created_at: `` },
-	{ id: -4, author_name: ``, message: `Сделай мне ням-ням`, created_at: `` },
+	{ id: -1, author_name: ``, message: `Продам опель астра`, amount: null, created_at: `` },
+	{ id: -2, author_name: ``, message: `Ищу девушку с остановки`, amount: null, created_at: `` },
+	{ id: -3, author_name: ``, message: `Хочу лето`, amount: null, created_at: `` },
+	{ id: -4, author_name: ``, message: `Сделай мне ням-ням`, amount: null, created_at: `` },
 ]
 
 function renderBannerImage(text: string, opacity: number): { width: number; height: number; data: Uint8Array } {


### PR DESCRIPTION
## Summary
- На iOS Safari не работал скролл в модалках (Donate и MapAdBanner) из-за `position: fixed` + `display: flex` + `align-items: center` — известный баг WebKit
- Overlay теперь сам является скролл-контейнером (`overflow-y: auto`), контент центрируется через `margin: auto` вместо flexbox
- Убран `max-height: 80vh` с внутреннего контента — модалка скроллится естественно

## Test plan
- [ ] Открыть модалку "О проекте" (донат) на iPhone — проверить что скроллится
- [ ] Открыть модалку "Доска объявлений" на iPhone — проверить скролл списка сообщений
- [ ] Проверить что клик по оверлею (вне контента) закрывает модалку
- [ ] Проверить на десктопе что модалки по-прежнему центрированы

https://claude.ai/code/session_01FfwGfy2MnAHubdf8QQHZfq