### PR TITLE
fix: modal scroll on iPhone — portal + remove role=button

### DIFF
--- a/frontend/src/features/Donate/ui/styled.module.css
+++ b/frontend/src/features/Donate/ui/styled.module.css
@@ -59,9 +59,9 @@
 	inset: 0;
 	z-index: 1100;
 	background: rgba(0, 0, 0, 0.4);
-	display: flex;
-	align-items: center;
-	justify-content: center;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	overscroll-behavior: contain;
 	padding: 16px;
 }
 
@@ -73,6 +73,7 @@
 	max-width: 400px;
 	width: 100%;
 	text-align: center;
+	margin: 16px auto;
 }
 
 .modalClose {

--- a/frontend/src/features/Donate/ui/styled.tsx
+++ b/frontend/src/features/Donate/ui/styled.tsx
@@ -42,11 +42,6 @@ export const ModalOverlayStyled: React.FC<{ onClick?: (e: React.MouseEvent) => v
 	<div
 		className={styles.modalOverlay}
 		onClick={onClick}
-		role="button"
-		tabIndex={0}
-		onKeyDown={e => {
-			if (e.key === `Enter` || e.key === ` `) onClick?.(e as unknown as React.MouseEvent)
-		}}
 	>
 		{children}
 	</div>

--- a/frontend/src/features/MapAdBanner/ui/MapAdBanner.module.css
+++ b/frontend/src/features/MapAdBanner/ui/MapAdBanner.module.css
@@ -5,9 +5,9 @@
   inset: 0;
   z-index: 1100;
   background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
   padding: 16px;
 }
 
@@ -18,10 +18,7 @@
   padding: 28px 20px 24px;
   max-width: 400px;
   width: 100%;
-  max-height: 80vh;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
+  margin: 16px auto;
 }
 
 .modalClose {

--- a/frontend/src/features/MapAdBanner/ui/MapAdBanner.tsx
+++ b/frontend/src/features/MapAdBanner/ui/MapAdBanner.tsx
@@ -17,10 +17,10 @@ const CANVAS_W = 240
 const CANVAS_H = 132
 
 const DEFAULT_MESSAGES: BannerMessage[] = [
-	{ id: -1, author_name: ``, message: `Продам опель астра`, created_at: `` },
-	{ id: -2, author_name: ``, message: `Ищу девушку с остановки`, created_at: `` },
-	{ id: -3, author_name: ``, message: `Хочу лето`, created_at: `` },
-	{ id: -4, author_name: ``, message: `Сделай мне ням-ням`, created_at: `` },
+	{ id: -1, author_name: ``, message: `Продам опель астра`, amount: null, created_at: `` },
+	{ id: -2, author_name: ``, message: `Ищу девушку с остановки`, amount: null, created_at: `` },
+	{ id: -3, author_name: ``, message: `Хочу лето`, amount: null, created_at: `` },
+	{ id: -4, author_name: ``, message: `Сделай мне ням-ням`, amount: null, created_at: `` },
 ]
 
 function renderBannerImage(text: string, opacity: number): { width: number; height: number; data: Uint8Array } {

--- a/frontend/src/features/MapAdBanner/ui/MapAdBannerModal.tsx
+++ b/frontend/src/features/MapAdBanner/ui/MapAdBannerModal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { AndrewLytics } from 'shared/lib'
 import { BannerMessage } from 'shared/api/scheduleApi'
 
@@ -36,7 +37,7 @@ export const MapAdBannerModal: React.FC<Props> = ({ isOpen, onClose, messages })
 
 	if (!isOpen) return null
 
-	return (
+	return createPortal(
 		<div
 			className={styles.modalOverlay}
 			onClick={handleOverlayClick}
@@ -116,6 +117,7 @@ export const MapAdBannerModal: React.FC<Props> = ({ isOpen, onClose, messages })
 					</div>
 				)}
 			</div>
-		</div>
+		</div>,
+		document.body,
 	)
 }


### PR DESCRIPTION
## Summary
- MapAdBannerModal рендерился внутри DOM-дерева карты — maplibre-gl перехватывал touch-события. Вынесен через `createPortal(document.body)`
- Donate overlay имел `role="button"` + `tabIndex={0}` — iOS трактовал весь overlay как кнопку, блокируя скролл. Убрано
- Overlay стал scroll-контейнером (`overflow-y: auto` + `margin: auto` вместо flex-центрирования)
- Фикс TS билда: добавлено `amount: null` в DEFAULT_MESSAGES

## Test plan
- [ ] Открыть модалку "Доска объявлений" на iPhone — проверить скролл списка сообщений
- [ ] Открыть модалку "О проекте" (донат) на iPhone — проверить скролл
- [ ] Клик по overlay (вне контента) закрывает модалку
- [ ] На десктопе модалки по-прежнему центрированы
- [ ] Билд проходит без ошибок

https://claude.ai/code/session_01FfwGfy2MnAHubdf8QQHZfq